### PR TITLE
Fix small things in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -47,7 +47,7 @@ n=$(find /payload/workflow -name "dockermeta.knime" |wc -l)
 
 #check for amount of workspace
 if [ $n == 0 ]; then
- echo "NON WORKSPACE FOUND. Check if the workflow directory is correctly specified"
+ echo "No workflow found. Check if the workflow directory was correctly specified during the build."
 elif [ $n == 1 ]; then
  wrk="${@:1}"
  workflow=""
@@ -59,7 +59,7 @@ elif [ $n -gt 1 ]; then
  # Check if file exists
  if [[ $execute == 1 && ! -f "/payload/workflow/$workflow/dockermeta.knime" ]]
  then
-    >&2 echo "Workflow not found. Check the name of the workflow."
+    >&2 echo "Workflow not found. Check the workflow name. Run the image with --info to see the contained workflows."
     n=0
  fi
 fi

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,9 @@ if [ "$workflow" = "--vars" ]; then
     echo "Workflow variables needed for executing the workflows:"
     echo "-----------------------------------------------------"
     while IFS=  read -r -d $'\0'; do
-      echo "$(dirname ${REPLY#./workflow/})"
+      # Cut off the "/payload/"" part because the user does not have to specify it
+      name="$(dirname ${REPLY#./workflow/})"
+      echo "${name:9}"
       echo -e 'Name\tType\tDefault Value'
       cat "$REPLY" | tr ':' '\t'
       echo "========"
@@ -22,7 +24,8 @@ elif [ "$workflow" = "--info" ]; then
     echo "Workflows:"
     echo "-----------------------------------------------------"
     while IFS=  read -r -d $'\0'; do
-      echo "$(dirname ${REPLY#./workflow/})"
+      name="$(dirname ${REPLY#./workflow/})"
+      echo "${name:9}"
     done < <(find "/payload/workflow" -name dockermeta.knime -print0)
     echo "-----------------------------------------------------"
     echo "Installed features:"
@@ -63,7 +66,6 @@ elif [ $n -gt 1 ]; then
     n=0
  fi
 fi
-
 
 if [[ $execute == 1 && $n -gt 0 ]] ; then
     for var in $wrk

--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,7 @@ elif [ "$workflow" = "--info" ]; then
     echo "-----------------------------------------------------"
     echo "Installed features:"
     echo "-----------------------------------------------------"
-    cat features
+    cat /payload/meta/features
     execute=0
 elif [ "$workflow" = "--help" ]; then
     echo "Help:"


### PR DESCRIPTION
1. The feature file was recently relocated to /payload/meta, but the run.sh was still looking in the current work directory.
2. There were some strangely written error and warning messages
3. With the --info or --vars option the full workflow path was shown, including the "/payload/" prefix. However, when the user wants to run the image, they should not specify that prefix and therefore I removed it from the output. To the user it should not matter in which folder the workflows are.
